### PR TITLE
Feat: Add variable ADC resolution

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -6,47 +6,29 @@ The PH4502C Sensor Arduino Library provides a comprehensive set of classes, func
 
 The PH4502C_Sensor class represents the PH4502C sensor and provides methods to initialize, calibrate, and read pH levels and temperature. It offers multiple constructors to accommodate different configuration needs.
 
+
 ### Constructors
 
-**PH4502C_Sensor(uint16_t ph_level_pin, uint16_t temp_pin)**
-
-- Parameters:
-    - ```ph_level_pin``` *(uint16_t)*: The Arduino analog pin connected to the pH level output of the sensor.
-
-    - ```temp_pin``` *(uint16_t)*: The Arduino analog pin connected to the temperature output of the sensor.
-
-**PH4502C_Sensor(uint16_t ph_level_pin, uint16_t temp_pin, float calibration)**
-
-- Parameters:
-    - ```ph_level_pin``` *(uint16_t)*: The Arduino analog pin connected to the pH level output of the sensor.
-
-    - ```temp_pin``` *(uint16_t)*: The Arduino analog pin connected to the temperature output of the sensor.
-
-    - ```calibration``` *(float)*: The calibration value to adjust pH readings.
-
-**PH4502C_Sensor(uint16_t ph_level_pin, uint16_t temp_pin, float calibration, int reading_interval)**
-
-- Parameters:
-    - ```ph_level_pin``` *(uint16_t)*: The Arduino analog pin connected to the pH level output of the sensor.
-
-    - ```temp_pin``` *(uint16_t)*: The Arduino analog pin connected to the temperature output of the sensor.
-
-    - ```calibration``` *(float)*: The calibration value to adjust pH readings.
-
-    - ```reading_interval``` *(int)**: The time interval between consecutive pH level readings in milliseconds.
-
-**PH4502C_Sensor(uint16_t ph_level_pin, uint16_t temp_pin, float calibration, int reading_interval, int reading_count)**
-
-- Parameters:
-    - ```ph_level_pin``` *(uint16_t)*: The Arduino analog pin connected to the pH level output of the sensor.
-
-    - ```temp_pin``` *(uint16_t)*: The Arduino analog pin connected to the temperature output of the sensor.
-
-    - ```calibration``` (float)*: The calibration value to adjust pH readings.
-
-    - ```reading_interval``` *(int)*: The time interval between consecutive pH level readings in milliseconds.
-
-    - ```reading_count``` *(int)**: The number of pH level readings to average when using ```read_ph_level()```.
+```cpp
+/**
+ * @brief Construct a new PH4502C_Sensor object.
+ * 
+ * @param ph_level_pin Analog pin connected to the pH level output of the sensor.
+ * @param temp_pin Analog pin connected to the temperature output of the sensor.
+ * @param calibration Calibration value to adjust pH readings (default is PH4502C_DEFAULT_CALIBRATION).
+ * @param reading_interval Time interval between consecutive pH level readings in milliseconds (default is PH4502C_DEFAULT_READING_INTERVAL).
+ * @param reading_count Number of pH level readings to average when using read_ph_level() (default is PH4502C_DEFAULT_READING_COUNT).
+ * @param adc_resolution ADC resolution used for voltage calculation from the analog read (default is PH4502C_DEFAULT_ADC_RESOLUTION).
+ */
+PH4502C_Sensor(uint16_t ph_level_pin, uint16_t temp_pin,
+               float calibration = PH4502C_DEFAULT_CALIBRATION,
+               int reading_interval = PH4502C_DEFAULT_READING_INTERVAL,
+               int reading_count = PH4502C_DEFAULT_READING_COUNT,
+               float adc_resolution = PH4502C_DEFAULT_ADC_RESOLUTION)
+    : _ph_level_pin(ph_level_pin), _temp_pin(temp_pin),
+      _calibration(calibration), _reading_interval(reading_interval),
+      _reading_count(reading_count), _adc_resolution(adc_resolution) {}
+```
 
 **PH4502C_Sensor::init()**
 
@@ -123,6 +105,39 @@ The ```PH4502C_DEFAULT_READING_COUNT``` constant represents the default number o
 
 ```cpp
 #define PH4502C_DEFAULT_READING_COUNT 10
+```
+
+**PH4502C_DEFAULT_ADC_RESOLUTION**
+
+The `PH4502C_DEFAULT_ADC_RESOLUTION` constant represents the default ADC resolution for the PH4502C sensor. The default value is set to `1024.0`.
+
+```cpp
+#define PH4502C_DEFAULT_ADC_RESOLUTION 1024.0f
+```
+
+**PH4502C_VOLTAGE**
+
+The `PH4502C_VOLTAGE` constant defines the operating voltage for the PH4502C sensor. The value is set to `5.0`.
+
+```cpp
+#define PH4502C_VOLTAGE 5.0f
+```
+
+**PH4502C_MID_VOLTAGE**
+
+The `PH4502C_MID_VOLTAGE` constant defines the voltage that represents a neutral pH reading (pH = 7). The value is set to `2.5`.
+
+```cpp
+#define PH4502C_MID_VOLTAGE 2.5f
+```
+
+**PH4502C_PH_VOLTAGE_PER_PH**
+
+The `PH4502C_PH_VOLTAGE_PER_PH` constant defines the rate of change in voltage per unit change in pH. The value is set to `0.18`.
+
+```cpp
+
+#define PH4502C_PH_VOLTAGE_PER_PH 0.18f
 ```
 
 ---

--- a/examples/advanced_example/full_example.ino
+++ b/examples/advanced_example/full_example.ino
@@ -1,0 +1,54 @@
+/**
+  *  Advanced example for PH4502C_Sensor.h
+  *
+  * This example shows how to use the library with an esp32 devboard.
+  *
+  * By: Pablo Alessandro Santos Hugen
+  * 21/10/2023
+  */
+
+#include <ph4502c_sensor.h>
+
+/* Pinout: https://cdn.awsli.com.br/969/969921/arquivos/ph-sensor-ph-4502c.pdf */
+#define PH4502C_TEMPERATURE_PIN 34
+#define PH4502C_PH_PIN 35
+#define PH4502C_PH_TRIGGER_PIN 14 
+#define PH4502C_CALIBRATION 14.8f
+#define PH4502C_READING_INTERVAL 100
+#define PH4502C_READING_COUNT 10
+// NOTE: The ESP32 ADC has a 12-bit resolution (while most arduinos have 10-bit)
+#define ADC_RESOLUTION 4096.0f
+
+// Create an instance of the PH4502C_Sensor
+PH4502C_Sensor ph4502c(
+  PH4502C_PH_PIN,
+  PH4502C_TEMPERATURE_PIN,
+  PH4502C_CALIBRATION,
+  PH4502C_READING_INTERVAL,
+  PH4502C_READING_COUNT,
+  ADC_RESOLUTION
+);
+
+void setup() {
+    Serial.begin(9600);
+    Serial.println("Starting PH4502C Sensor...");
+
+    // Initialize the PH4502 instance
+    ph4502.init();
+}
+
+void loop() {
+    // Read the temperature from the sensor
+    Serial.println("Temperature reading:"
+        + String(ph4502.read_temp()));
+
+    // Read the pH level by average
+    Serial.println("pH Level Reading: "
+        + String(ph4502.read_ph_level()));
+
+    // Read a single pH level value
+    Serial.println("pH Level Single Reading: "
+        + String(ph4502.read_ph_level_single()));
+
+    delay(1000);
+}

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "PH4502C-Sensor",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Arduino library for PH4502C sensor.",
     "keywords": "PH4502C, Water Quality Sensor",
     "repository": {
@@ -12,6 +12,11 @@
         "name": "nathannestein",
         "email": "nathanneisip@gmail.com",
         "url": "https://nthnn.github.io/"
+      },
+      {
+        "name": "Pablo Alessandro Santos Hugen",
+        "email": "PabloASHugen@protonmail.com",
+        "url": "https://tomcat0x42.me"
       }
     ],
     "license": "MIT",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=PH4502C-Sensor
-version=1.0.0
+version=1.1.0
 author=nthnn
 maintainer=nthnn
 sentence=Arduino library for PH4502C sensor.

--- a/src/ph4502c_sensor.cpp
+++ b/src/ph4502c_sensor.cpp
@@ -18,9 +18,9 @@ float PH4502C_Sensor::read_ph_level() {
         delayMicroseconds(this->_reading_interval);
     }
 
-    reading = 5 / 1024.0 * reading;
+    reading = PH4502C_VOLTAGE / this->_adc_resolution * reading;
     reading /= this->_reading_count;
-    reading = this->_calibration + ((2.5 - reading)) / 0.18;
+    reading = this->_calibration + ((PH4502C_MID_VOLTAGE - reading)) / PH4502C_PH_VOLTAGE_PER_PH;
 
     return reading;
 }
@@ -28,10 +28,10 @@ float PH4502C_Sensor::read_ph_level() {
 float PH4502C_Sensor::read_ph_level_single() {
     float reading = analogRead(this->_ph_level_pin);
 
-    reading = 5 / 1024.0 * reading;
+    reading = PH4502C_VOLTAGE / this->_adc_resolution * reading;
     reading /= this->_reading_count;
 
-    return this->_calibration + ((2.5 - reading)) / 0.18;
+    return this->_calibration + ((PH4502C_MID_VOLTAGE - reading)) / PH4502C_PH_VOLTAGE_PER_PH;
 }
 
 int PH4502C_Sensor::read_temp() {

--- a/src/ph4502c_sensor.h
+++ b/src/ph4502c_sensor.h
@@ -3,53 +3,92 @@
 
 #include <Arduino.h>
 
+/// Default calibration value for the PH4502C sensor.
 #define PH4502C_DEFAULT_CALIBRATION 14.8f
+
+/// Default reading interval (in milliseconds) between pH readings.
 #define PH4502C_DEFAULT_READING_INTERVAL 100
+
+/// Default number of pH readings to average.
 #define PH4502C_DEFAULT_READING_COUNT 10
 
+/// Default ADC resolution for the PH4502C sensor.
+#define PH4502C_DEFAULT_ADC_RESOLUTION 1024.0f
+
+/// Operating voltage for the PH4502C sensor.
+#define PH4502C_VOLTAGE 5.0f
+
+/// Voltage that represents a neutral pH reading (pH = 7).
+#define PH4502C_MID_VOLTAGE 2.5f
+
+/// Rate of change in voltage per unit change in pH.
+#define PH4502C_PH_VOLTAGE_PER_PH 0.18f
+
+/**
+ * @brief A class to interface with the PH4502C pH sensor.
+ */
 class PH4502C_Sensor {
     public:
 
-    PH4502C_Sensor(uint16_t ph_level_pin, uint16_t temp_pin):
-        _ph_level_pin(ph_level_pin),
-        _temp_pin(temp_pin),
-        _calibration(PH4502C_DEFAULT_CALIBRATION),
-        _reading_interval(PH4502C_DEFAULT_READING_INTERVAL),
-        _reading_count(PH4502C_DEFAULT_READING_COUNT) { }
+    /**
+     * @brief Construct a new PH4502C_Sensor object.
+     * 
+     * @param ph_level_pin Analog pin connected to the pH level output of the sensor.
+     * @param temp_pin Analog pin connected to the temperature output of the sensor.
+     * @param calibration Calibration value to adjust pH readings (default is PH4502C_DEFAULT_CALIBRATION).
+     * @param reading_interval Time interval between consecutive pH level readings in milliseconds (default is PH4502C_DEFAULT_READING_INTERVAL).
+     * @param reading_count Number of pH level readings to average when using read_ph_level() (default is PH4502C_DEFAULT_READING_COUNT).
+     * @param adc_resolution ADC resolution used for voltage calculation from the analog read (default is PH4502C_DEFAULT_ADC_RESOLUTION).
+     */
+    PH4502C_Sensor(uint16_t ph_level_pin, uint16_t temp_pin,
+                   float calibration = PH4502C_DEFAULT_CALIBRATION,
+                   int reading_interval = PH4502C_DEFAULT_READING_INTERVAL,
+                   int reading_count = PH4502C_DEFAULT_READING_COUNT,
+                   float adc_resolution = PH4502C_DEFAULT_ADC_RESOLUTION)
+        : _ph_level_pin(ph_level_pin), _temp_pin(temp_pin),
+          _calibration(calibration), _reading_interval(reading_interval),
+          _reading_count(reading_count), _adc_resolution(adc_resolution) {}
 
-    PH4502C_Sensor(uint16_t ph_level_pin, uint16_t temp_pin, float calibration):
-        _ph_level_pin(ph_level_pin),
-        _temp_pin(temp_pin),
-        _calibration(calibration),
-        _reading_interval(PH4502C_DEFAULT_READING_INTERVAL),
-        _reading_count(PH4502C_DEFAULT_READING_COUNT) { }
-
-    PH4502C_Sensor(uint16_t ph_level_pin, uint16_t temp_pin, float calibration, int reading_interval):
-        _ph_level_pin(ph_level_pin),
-        _temp_pin(temp_pin),
-        _calibration(calibration),
-        _reading_interval(reading_interval),
-        _reading_count(PH4502C_DEFAULT_READING_COUNT) { }
-
-    PH4502C_Sensor(uint16_t ph_level_pin, uint16_t temp_pin, float calibration, int reading_interval, int reading_count):
-        _ph_level_pin(ph_level_pin),
-        _temp_pin(temp_pin),
-        _calibration(calibration),
-        _reading_interval(reading_interval),
-        _reading_count(reading_count) { }
-
+    /**
+     * @brief Initialize the pH and temperature sensor pins.
+     */
     void init();
+
+    /**
+     * @brief Recalibrate the pH readings with a new calibration value.
+     * 
+     * @param calibration New calibration value for pH readings.
+     */
     void recalibrate(float calibration);
 
+    /**
+     * @brief Read the pH level, averaging over multiple readings.
+     * 
+     * @return float Averaged pH value.
+     */
     float read_ph_level();
+
+    /**
+     * @brief Read the pH level for a single reading.
+     * 
+     * @return float pH value from a single reading.
+     */
     float read_ph_level_single();
+
+    /**
+     * @brief Read the temperature value.
+     * 
+     * @return int Analog reading from the temperature pin.
+     */
     int read_temp();
 
     private:
-    uint16_t _ph_level_pin, _temp_pin;
-    int _reading_interval, _reading_count;
-
-    float _calibration;
+    uint16_t _ph_level_pin; ///< Analog pin for pH level readings.
+    uint16_t _temp_pin;     ///< Analog pin for temperature readings.
+    int _reading_interval;  ///< Interval between pH readings.
+    int _reading_count;     ///< Number of pH readings to average.
+    float _calibration;     ///< Calibration value for pH readings.
+    float _adc_resolution;  ///< ADC resolution for voltage calculation.
 };
 
 #endif


### PR DESCRIPTION
First of all, great library!!!

I've tried to used it in an ESP32 dev board, and I noticed that the ADC resolution used for analog readings was hardcoded. For most arduinos, the ADC resolution is 10 bits (1024), but for example the ESP32 is 12 bits (4096).

So, considering this, I've added this as a constructor parameter. Also, I did some minor tweaks like refactoring magic numbers into macros for increased readability.

PS: Can you please add the flag `hacktoberfest-accepted` to this pr?

Thanks!!!!
